### PR TITLE
Support for Astronomy units

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ viewer.scalebar({
 });
 `````
 
+To change the unit system from the default of Metric to Astronomical,
+you must reference the `sizeAndTextRenderer` function in the library directly:
+
+`````javascript
+viewer.scalebar({
+  ...
+  sizeAndTextRenderer: OpenSeadragon.ScalebarSizeAndTextRenderer.ASTRONOMY,
+  ...
+});
+`````
+
 The list of all the options can be found and tested on the [demo site](https://pages.nist.gov/OpenSeadragonScalebar/).
 
 If type, pixelsPerMeter or location are not set (or set to 0), the bar is hidden.

--- a/openseadragon-scalebar.js
+++ b/openseadragon-scalebar.js
@@ -431,7 +431,7 @@
             }
             var ppd = ppminutes * 60;
             return getScalebarSizeAndText(ppd, minSize, "&#176", false, '');
-	    },
+	},
         /**
          * Standard time. Choosing the best unit from second (and metric divisions),
          * minute, hour, day and year.
@@ -475,7 +475,8 @@
         return ratio * viewportZoom;
     }
 
-    function getScalebarSizeAndText(ppm, minSize, unitSuffix, handlePlural, spacer = ' ') {
+    function getScalebarSizeAndText(ppm, minSize, unitSuffix, handlePlural, spacer) {
+	spacer = spacer === undefined ? ' ' : spacer;
         var value = normalize(ppm, minSize);
         var factor = roundSignificand(value / ppm * minSize, 3);
         var size = value * minSize;

--- a/openseadragon-scalebar.js
+++ b/openseadragon-scalebar.js
@@ -418,6 +418,21 @@
             return getScalebarSizeAndText(ppmi, minSize, "mi");
         },
         /**
+         * Astronomy units. Choosing the best unit from arcsec, arcminute, and degree
+         */
+        ASTRONOMY: function(ppa, minSize) {
+	    var maxSize = minSize * 2;
+            if (maxSize < ppa * 60) {
+                return getScalebarSizeAndText(ppa, minSize, "\"", false, '');
+            }
+            var ppminutes = ppa * 60;
+            if (maxSize < ppminutes * 60) {
+                return getScalebarSizeAndText(ppminutes, minSize, "\'", false, '');
+            }
+            var ppd = ppminutes * 60;
+            return getScalebarSizeAndText(ppd, minSize, "&#176", false, '');
+	    },
+        /**
          * Standard time. Choosing the best unit from second (and metric divisions),
          * minute, hour, day and year.
          */
@@ -460,14 +475,14 @@
         return ratio * viewportZoom;
     }
 
-    function getScalebarSizeAndText(ppm, minSize, unitSuffix, handlePlural) {
+    function getScalebarSizeAndText(ppm, minSize, unitSuffix, handlePlural, spacer = ' ') {
         var value = normalize(ppm, minSize);
         var factor = roundSignificand(value / ppm * minSize, 3);
         var size = value * minSize;
         var plural = handlePlural && factor > 1 ? "s" : "";
         return {
             size: size,
-            text: factor + " " + unitSuffix + plural
+            text: factor + spacer + unitSuffix + plural
         };
     }
 


### PR DESCRIPTION
Astronomers typically use units of arcsecond, arcminute, and degree to define distances between points on the sky.  This change adds an ASTRONOMY option to the ScalebarSizeAndTextRenderer that handles and displays these values with the correct units when pixelsPerMeter is set to correct value of pixels per arcsecond (inverse of the pixelscale) in the original image.  