### PR TITLE
Fixed issue with scalebar drawing off bottom of screen in fullscreen mode

### DIFF
--- a/openseadragon-scalebar.js
+++ b/openseadragon-scalebar.js
@@ -16,8 +16,9 @@
  */
 (function($) {
 
-    if (!$.version || $.version.major < 1) {
-        throw new Error('OpenSeadragonScalebar requires OpenSeadragon version 1.0.0+');
+    if (!$.version || $.version.major < 2) {
+        throw new Error('This version of OpenSeadragonScalebar requires ' +
+                'OpenSeadragon version 2.0.0+');
     }
 
     $.Viewer.prototype.scalebar = function(options) {
@@ -55,6 +56,9 @@
      * @param {Integer} options.pixelsPerMeter The pixels per meter of the
      * zoomable image at the original image size. If null, the scale bar is not
      * displayed. default: null
+     * @param {Integer} options.referenceItemIdx Specify the item from
+     * viewer.world to which options.pixelsPerMeter is refering.
+     * default: 0
      * @param (String} options.minWidth The minimal width of the scale bar as a
      * CSS string (ex: 100px, 1em, 1% etc...) default: 150px
      * @param {OpenSeadragon.ScalebarLocation} options.location The location
@@ -70,6 +74,7 @@
      * @param {String} options.fontColor The font color. default: black
      * @param {String} options.backgroundColor The background color. default: none
      * @param {String} options.fontSize The font size. default: not set
+     * @param {String} options.fontFamily The font-family. default: not set
      * @param {String} options.barThickness The thickness of the scale bar in px.
      * default: 2
      * @param {function} options.sizeAndTextRenderer A function which will be
@@ -89,7 +94,6 @@
         this.divElt = document.createElement("div");
         this.viewer.container.appendChild(this.divElt);
         this.divElt.style.position = "relative";
-        this.divElt.id = "scalebarDiv";
         this.divElt.style.margin = "0";
         this.divElt.style.pointerEvents = "none";
 
@@ -100,8 +104,10 @@
         this.fontColor = options.fontColor || "black";
         this.backgroundColor = options.backgroundColor || "none";
         this.fontSize = options.fontSize || "";
+        this.fontFamily = options.fontFamily || "";
         this.barThickness = options.barThickness || 2;
         this.pixelsPerMeter = options.pixelsPerMeter || null;
+        this.referenceItemIdx = options.referenceItemIdx || 0;
         this.location = options.location || $.ScalebarLocation.BOTTOM_LEFT;
         this.xOffset = options.xOffset || 5;
         this.yOffset = options.yOffset || 5;
@@ -145,11 +151,17 @@
             if (isDefined(options.fontSize)) {
                 this.fontSize = options.fontSize;
             }
+            if (isDefined(options.fontFamily)) {
+                this.fontFamily = options.fontFamily;
+            }
             if (isDefined(options.barThickness)) {
                 this.barThickness = options.barThickness;
             }
             if (isDefined(options.pixelsPerMeter)) {
                 this.pixelsPerMeter = options.pixelsPerMeter;
+            }
+            if (isDefined(options.referenceItemIdx)) {
+                this.referenceItemIdx = options.referenceItemIdx;
             }
             if (isDefined(options.location)) {
                 this.location = options.location;
@@ -191,6 +203,9 @@
          * @param {Integer} options.pixelsPerMeter The pixels per meter of the
          * zoomable image at the original image size. If null, the scale bar is not
          * displayed. default: null
+         * @param {Integer} options.referenceItemIdx Specify the item from
+         * viewer.world to which options.pixelsPerMeter is refering.
+         * default: 0
          * @param (String} options.minWidth The minimal width of the scale bar as a
          * CSS string (ex: 100px, 1em, 1% etc...) default: 150px
          * @param {OpenSeadragon.ScalebarLocation} options.location The location
@@ -228,7 +243,9 @@
             this.divElt.style.display = "";
 
             var viewport = this.viewer.viewport;
-            var zoom = viewport.viewportToImageZoom(viewport.getZoom(true));
+            var tiledImage = this.viewer.world.getItemAt(this.referenceItemIdx);
+            var zoom = tiledImageViewportToImageZoom(tiledImage,
+                    viewport.getZoom(true));
             var currentPPM = zoom * this.pixelsPerMeter;
             var props = this.sizeAndTextRenderer(currentPPM, this.minWidth);
 
@@ -239,6 +256,7 @@
         },
         drawMicroscopyScalebar: function(size, text) {
             this.divElt.style.fontSize = this.fontSize;
+            this.divElt.style.fontFamily = this.fontFamily;
             this.divElt.style.textAlign = "center";
             this.divElt.style.color = this.fontColor;
             this.divElt.style.border = "none";
@@ -249,6 +267,7 @@
         },
         drawMapScalebar: function(size, text) {
             this.divElt.style.fontSize = this.fontSize;
+            this.divElt.style.fontFamily = this.fontFamily;
             this.divElt.style.textAlign = "center";
             this.divElt.style.color = this.fontColor;
             this.divElt.style.border = this.barThickness + "px solid " + this.color;
@@ -298,7 +317,6 @@
                 var barWidth = this.divElt.offsetWidth;
                 var barHeight = this.divElt.offsetHeight;
                 var container = this.viewer.container;
-
                 var x = container.offsetWidth - barWidth;
                 var y = container.offsetHeight - barHeight;
                 var toolbar = this.viewer.toolbar;
@@ -306,7 +324,6 @@
                 {
                     y -= toolbar.element.offsetHeight;
                 }
-
                 if (this.stayInsideImage) {
                     var pixel = this.viewer.viewport.pixelFromPoint(
                             new $.Point(1, 1 / this.viewer.source.aspectRatio),
@@ -343,6 +360,50 @@
                 }
                 return new $.Point(x + this.xOffset, y - this.yOffset);
             }
+        },
+        /**
+         * Get the rendered scalebar in a canvas.
+         * @returns {Element} A canvas containing the scalebar representation
+         */
+        getAsCanvas: function() {
+            var canvas = document.createElement("canvas");
+            canvas.width = this.divElt.offsetWidth;
+            canvas.height = this.divElt.offsetHeight;
+            var context = canvas.getContext("2d");
+            context.fillStyle = this.backgroundColor;
+            context.fillRect(0, 0, canvas.width, canvas.height);
+            context.fillStyle = this.color;
+            context.fillRect(0, canvas.height - this.barThickness,
+                    canvas.width, canvas.height);
+            if (this.drawScalebar === this.drawMapScalebar) {
+                context.fillRect(0, 0, this.barThickness, canvas.height);
+                context.fillRect(canvas.width - this.barThickness, 0,
+                        this.barThickness, canvas.height);
+            }
+            context.font = window.getComputedStyle(this.divElt).font;
+            context.textAlign = "center";
+            context.textBaseline = "middle";
+            context.fillStyle = this.fontColor;
+            var hCenter = canvas.width / 2;
+            var vCenter = canvas.height / 2;
+            context.fillText(this.divElt.textContent, hCenter, vCenter);
+            return canvas;
+        },
+        /**
+         * Get a copy of the current OpenSeadragon canvas with the scalebar.
+         * @returns {Element} A canvas containing a copy of the current OpenSeadragon canvas with the scalebar
+         */
+        getImageWithScalebarAsCanvas: function() {
+            var imgCanvas = this.viewer.drawer.canvas;
+            var newCanvas = document.createElement("canvas");
+            newCanvas.width = imgCanvas.width;
+            newCanvas.height = imgCanvas.height;
+            var newCtx = newCanvas.getContext("2d");
+            newCtx.drawImage(imgCanvas, 0, 0);
+            var scalebarCanvas = this.getAsCanvas();
+            var location = this.getScalebarLocation();
+            newCtx.drawImage(scalebarCanvas, location.x, location.y);
+            return newCanvas;
         }
     };
 
@@ -373,6 +434,21 @@
             var ppmi = ppf * 5280;
             return getScalebarSizeAndText(ppmi, minSize, "mi");
         },
+        /**
+         * Astronomy units. Choosing the best unit from arcsec, arcminute, and degree
+         */
+        ASTRONOMY: function(ppa, minSize) {
+	    var maxSize = minSize * 2;
+            if (maxSize < ppa * 60) {
+                return getScalebarSizeAndText(ppa, minSize, "\"", false, '');
+            }
+            var ppminutes = ppa * 60;
+            if (maxSize < ppminutes * 60) {
+                return getScalebarSizeAndText(ppminutes, minSize, "\'", false, '');
+            }
+            var ppd = ppminutes * 60;
+            return getScalebarSizeAndText(ppd, minSize, "&#176", false, '');
+	},
         /**
          * Standard time. Choosing the best unit from second (and metric divisions),
          * minute, hour, day and year.
@@ -408,14 +484,23 @@
         METRIC_GENERIC: getScalebarSizeAndTextForMetric
     };
 
-    function getScalebarSizeAndText(ppm, minSize, unitSuffix, handlePlural) {
+    // Missing TiledImage.viewportToImageZoom function in OSD 2.0.0
+    function tiledImageViewportToImageZoom(tiledImage, viewportZoom) {
+        var ratio = tiledImage._scaleSpring.current.value *
+                tiledImage.viewport._containerInnerSize.x /
+                tiledImage.source.dimensions.x;
+        return ratio * viewportZoom;
+    }
+
+    function getScalebarSizeAndText(ppm, minSize, unitSuffix, handlePlural, spacer) {
+	spacer = spacer === undefined ? ' ' : spacer;
         var value = normalize(ppm, minSize);
         var factor = roundSignificand(value / ppm * minSize, 3);
         var size = value * minSize;
         var plural = handlePlural && factor > 1 ? "s" : "";
         return {
             size: size,
-            text: factor + " " + unitSuffix + plural
+            text: factor + spacer + unitSuffix + plural
         };
     }
 

--- a/openseadragon-scalebar.js
+++ b/openseadragon-scalebar.js
@@ -16,9 +16,8 @@
  */
 (function($) {
 
-    if (!$.version || $.version.major < 2) {
-        throw new Error('This version of OpenSeadragonScalebar requires ' +
-                'OpenSeadragon version 2.0.0+');
+    if (!$.version || $.version.major < 1) {
+        throw new Error('OpenSeadragonScalebar requires OpenSeadragon version 1.0.0+');
     }
 
     $.Viewer.prototype.scalebar = function(options) {
@@ -56,9 +55,6 @@
      * @param {Integer} options.pixelsPerMeter The pixels per meter of the
      * zoomable image at the original image size. If null, the scale bar is not
      * displayed. default: null
-     * @param {Integer} options.referenceItemIdx Specify the item from
-     * viewer.world to which options.pixelsPerMeter is refering.
-     * default: 0
      * @param (String} options.minWidth The minimal width of the scale bar as a
      * CSS string (ex: 100px, 1em, 1% etc...) default: 150px
      * @param {OpenSeadragon.ScalebarLocation} options.location The location
@@ -74,7 +70,6 @@
      * @param {String} options.fontColor The font color. default: black
      * @param {String} options.backgroundColor The background color. default: none
      * @param {String} options.fontSize The font size. default: not set
-     * @param {String} options.fontFamily The font-family. default: not set
      * @param {String} options.barThickness The thickness of the scale bar in px.
      * default: 2
      * @param {function} options.sizeAndTextRenderer A function which will be
@@ -94,6 +89,7 @@
         this.divElt = document.createElement("div");
         this.viewer.container.appendChild(this.divElt);
         this.divElt.style.position = "relative";
+        this.divElt.id = "scalebarDiv";
         this.divElt.style.margin = "0";
         this.divElt.style.pointerEvents = "none";
 
@@ -104,10 +100,8 @@
         this.fontColor = options.fontColor || "black";
         this.backgroundColor = options.backgroundColor || "none";
         this.fontSize = options.fontSize || "";
-        this.fontFamily = options.fontFamily || "";
         this.barThickness = options.barThickness || 2;
         this.pixelsPerMeter = options.pixelsPerMeter || null;
-        this.referenceItemIdx = options.referenceItemIdx || 0;
         this.location = options.location || $.ScalebarLocation.BOTTOM_LEFT;
         this.xOffset = options.xOffset || 5;
         this.yOffset = options.yOffset || 5;
@@ -151,17 +145,11 @@
             if (isDefined(options.fontSize)) {
                 this.fontSize = options.fontSize;
             }
-            if (isDefined(options.fontFamily)) {
-                this.fontFamily = options.fontFamily;
-            }
             if (isDefined(options.barThickness)) {
                 this.barThickness = options.barThickness;
             }
             if (isDefined(options.pixelsPerMeter)) {
                 this.pixelsPerMeter = options.pixelsPerMeter;
-            }
-            if (isDefined(options.referenceItemIdx)) {
-                this.referenceItemIdx = options.referenceItemIdx;
             }
             if (isDefined(options.location)) {
                 this.location = options.location;
@@ -203,9 +191,6 @@
          * @param {Integer} options.pixelsPerMeter The pixels per meter of the
          * zoomable image at the original image size. If null, the scale bar is not
          * displayed. default: null
-         * @param {Integer} options.referenceItemIdx Specify the item from
-         * viewer.world to which options.pixelsPerMeter is refering.
-         * default: 0
          * @param (String} options.minWidth The minimal width of the scale bar as a
          * CSS string (ex: 100px, 1em, 1% etc...) default: 150px
          * @param {OpenSeadragon.ScalebarLocation} options.location The location
@@ -243,9 +228,7 @@
             this.divElt.style.display = "";
 
             var viewport = this.viewer.viewport;
-            var tiledImage = this.viewer.world.getItemAt(this.referenceItemIdx);
-            var zoom = tiledImageViewportToImageZoom(tiledImage,
-                    viewport.getZoom(true));
+            var zoom = viewport.viewportToImageZoom(viewport.getZoom(true));
             var currentPPM = zoom * this.pixelsPerMeter;
             var props = this.sizeAndTextRenderer(currentPPM, this.minWidth);
 
@@ -256,7 +239,6 @@
         },
         drawMicroscopyScalebar: function(size, text) {
             this.divElt.style.fontSize = this.fontSize;
-            this.divElt.style.fontFamily = this.fontFamily;
             this.divElt.style.textAlign = "center";
             this.divElt.style.color = this.fontColor;
             this.divElt.style.border = "none";
@@ -267,7 +249,6 @@
         },
         drawMapScalebar: function(size, text) {
             this.divElt.style.fontSize = this.fontSize;
-            this.divElt.style.fontFamily = this.fontFamily;
             this.divElt.style.textAlign = "center";
             this.divElt.style.color = this.fontColor;
             this.divElt.style.border = this.barThickness + "px solid " + this.color;
@@ -317,8 +298,15 @@
                 var barWidth = this.divElt.offsetWidth;
                 var barHeight = this.divElt.offsetHeight;
                 var container = this.viewer.container;
+
                 var x = container.offsetWidth - barWidth;
                 var y = container.offsetHeight - barHeight;
+                var toolbar = this.viewer.toolbar;
+                if (toolbar && this.viewer.isFullPage())
+                {
+                    y -= toolbar.element.offsetHeight;
+                }
+
                 if (this.stayInsideImage) {
                     var pixel = this.viewer.viewport.pixelFromPoint(
                             new $.Point(1, 1 / this.viewer.source.aspectRatio),
@@ -337,6 +325,11 @@
                 var container = this.viewer.container;
                 var x = 0;
                 var y = container.offsetHeight - barHeight;
+                var toolbar = this.viewer.toolbar;
+                if (toolbar && this.viewer.isFullPage())
+                {
+                    y -= toolbar.element.offsetHeight;
+                }
                 if (this.stayInsideImage) {
                     var pixel = this.viewer.viewport.pixelFromPoint(
                             new $.Point(0, 1 / this.viewer.source.aspectRatio),
@@ -350,50 +343,6 @@
                 }
                 return new $.Point(x + this.xOffset, y - this.yOffset);
             }
-        },
-        /**
-         * Get the rendered scalebar in a canvas.
-         * @returns {Element} A canvas containing the scalebar representation
-         */
-        getAsCanvas: function() {
-            var canvas = document.createElement("canvas");
-            canvas.width = this.divElt.offsetWidth;
-            canvas.height = this.divElt.offsetHeight;
-            var context = canvas.getContext("2d");
-            context.fillStyle = this.backgroundColor;
-            context.fillRect(0, 0, canvas.width, canvas.height);
-            context.fillStyle = this.color;
-            context.fillRect(0, canvas.height - this.barThickness,
-                    canvas.width, canvas.height);
-            if (this.drawScalebar === this.drawMapScalebar) {
-                context.fillRect(0, 0, this.barThickness, canvas.height);
-                context.fillRect(canvas.width - this.barThickness, 0,
-                        this.barThickness, canvas.height);
-            }
-            context.font = window.getComputedStyle(this.divElt).font;
-            context.textAlign = "center";
-            context.textBaseline = "middle";
-            context.fillStyle = this.fontColor;
-            var hCenter = canvas.width / 2;
-            var vCenter = canvas.height / 2;
-            context.fillText(this.divElt.textContent, hCenter, vCenter);
-            return canvas;
-        },
-        /**
-         * Get a copy of the current OpenSeadragon canvas with the scalebar.
-         * @returns {Element} A canvas containing a copy of the current OpenSeadragon canvas with the scalebar
-         */
-        getImageWithScalebarAsCanvas: function() {
-            var imgCanvas = this.viewer.drawer.canvas;
-            var newCanvas = document.createElement("canvas");
-            newCanvas.width = imgCanvas.width;
-            newCanvas.height = imgCanvas.height;
-            var newCtx = newCanvas.getContext("2d");
-            newCtx.drawImage(imgCanvas, 0, 0);
-            var scalebarCanvas = this.getAsCanvas();
-            var location = this.getScalebarLocation();
-            newCtx.drawImage(scalebarCanvas, location.x, location.y);
-            return newCanvas;
         }
     };
 
@@ -424,21 +373,6 @@
             var ppmi = ppf * 5280;
             return getScalebarSizeAndText(ppmi, minSize, "mi");
         },
-        /**
-         * Astronomy units. Choosing the best unit from arcsec, arcminute, and degree
-         */
-        ASTRONOMY: function(ppa, minSize) {
-	    var maxSize = minSize * 2;
-            if (maxSize < ppa * 60) {
-                return getScalebarSizeAndText(ppa, minSize, "\"", false, '');
-            }
-            var ppminutes = ppa * 60;
-            if (maxSize < ppminutes * 60) {
-                return getScalebarSizeAndText(ppminutes, minSize, "\'", false, '');
-            }
-            var ppd = ppminutes * 60;
-            return getScalebarSizeAndText(ppd, minSize, "&#176", false, '');
-	},
         /**
          * Standard time. Choosing the best unit from second (and metric divisions),
          * minute, hour, day and year.
@@ -474,23 +408,14 @@
         METRIC_GENERIC: getScalebarSizeAndTextForMetric
     };
 
-    // Missing TiledImage.viewportToImageZoom function in OSD 2.0.0
-    function tiledImageViewportToImageZoom(tiledImage, viewportZoom) {
-        var ratio = tiledImage._scaleSpring.current.value *
-                tiledImage.viewport._containerInnerSize.x /
-                tiledImage.source.dimensions.x;
-        return ratio * viewportZoom;
-    }
-
-    function getScalebarSizeAndText(ppm, minSize, unitSuffix, handlePlural, spacer) {
-	spacer = spacer === undefined ? ' ' : spacer;
+    function getScalebarSizeAndText(ppm, minSize, unitSuffix, handlePlural) {
         var value = normalize(ppm, minSize);
         var factor = roundSignificand(value / ppm * minSize, 3);
         var size = value * minSize;
         var plural = handlePlural && factor > 1 ? "s" : "";
         return {
             size: size,
-            text: factor + spacer + unitSuffix + plural
+            text: factor + " " + unitSuffix + plural
         };
     }
 


### PR DESCRIPTION
If user set an external toolbar to openseadragon, then the scalebar would draw off bottom of the page in fullscreen mode (if BOTTOM_LEFT or BOTTOM_RIGHT position specified) because openseadragon adds the toolbar to the top of the page.